### PR TITLE
[python][AbstractHumanoidRobot] Remove default signal creation.

### DIFF
--- a/src/dynamic_graph/sot/dynamics_pinocchio/humanoid_robot.py
+++ b/src/dynamic_graph/sot/dynamics_pinocchio/humanoid_robot.py
@@ -263,7 +263,7 @@ class AbstractHumanoidRobot (object):
         else:
             self.dynamic.acceleration.value = self.dimension*(0.,)
 
-        self.initializeOpPoints()
+        #self.initializeOpPoints()
 
         #TODO: hand parameters through srdf --- additional frames ---
         #self.frames = dict()


### PR DESCRIPTION
* Position and Jacobian signals should be created when called