### PR TITLE
Remove useless headers + update cmake submodules

### DIFF
--- a/src/python-module-py.cpp
+++ b/src/python-module-py.cpp
@@ -18,9 +18,6 @@
 #include <boost/python.hpp>
 #include <typeinfo>
 #include <cstdio>
-#include <pinocchio/bindings/python/multibody/model.hpp>
-#include <pinocchio/bindings/python/multibody/data.hpp>
-#include <pinocchio/bindings/python/utils/handler.hpp>
 
 
 namespace dynamicgraph{


### PR DESCRIPTION
The headers using pinocchio bindings are useless and create unnecessary dependencies.
This commit fix this.
