### PR TITLE
Fix wrong dependencies, wrong doxygen tags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ SET(DOXYGEN_USE_MATHJAX YES)
 # JRL-cmakemodule setup
 INCLUDE(cmake/base.cmake)
 INCLUDE(cmake/boost.cmake)
+INCLUDE(cmake/lapack.cmake)
 INCLUDE(cmake/python.cmake)
 INCLUDE(cmake/sphinx.cmake)
 

--- a/doc/Doxyfile.extra.in
+++ b/doc/Doxyfile.extra.in
@@ -5,6 +5,5 @@ IMAGE_PATH             = @CMAKE_SOURCE_DIR@/doc/pictures
 FILE_PATTERNS          = *.cc *.cpp *.h *.hh *.hxx
 
 TAGFILES               = \
-"@JRL_MAL_DOXYGENDOCDIR@/jrl-mal.doxytag = @JRL_MAL_DOXYGENDOCDIR@" \
 "@DYNAMIC_GRAPH_DOXYGENDOCDIR@/dynamic-graph.doxytag = @DYNAMIC_GRAPH_DOXYGENDOCDIR@" \
 "@SOT_CORE_DOXYGENDOCDIR@/sot-core.doxytag = @SOT_CORE_DOXYGENDOCDIR@"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,7 +18,8 @@ SET(plugins
   )
 
 SET(integrator-force-rk4_plugins_deps integrator-force)
-SET(integrator-force-exact_plugins_deps integrator-force)
+SET(integrator-force-exact_plugins_deps integrator-force lapack)
+SET(mass-apparent_plugins_deps integrator-force)
 
 FOREACH(plugin ${plugins})
   GET_FILENAME_COMPONENT(LIBRARY_NAME ${plugin} NAME)
@@ -28,7 +29,8 @@ FOREACH(plugin ${plugins})
     SET_TARGET_PROPERTIES(${LIBRARY_NAME} PROPERTIES SOVERSION ${PROJECT_VERSION})
   ENDIF(SUFFIX_SO_VERSION)
 
-  TARGET_LINK_LIBRARIES(${LIBRARY_NAME} ${PROJECT_NAME} ${${LIBRARY_NAME}_deps})
+  TARGET_LINK_LIBRARIES(${LIBRARY_NAME}
+    PUBLIC ${PROJECT_NAME} ${${LIBRARY_NAME}_plugins_deps})
 
   IF(NOT INSTALL_PYTHON_INTERFACE_ONLY)
     INSTALL(TARGETS ${LIBRARY_NAME} EXPORT ${TARGETS_EXPORT_NAME}


### PR DESCRIPTION
This PR includes fixes for:
 * Wrong dependencies of integrator-forces-rk45 and integrator-forces-exact to integrator-force
 * Reference to a package which has been removed jrl-mal.
 * Add dependency to LAPACK missing on Mac OS.

It also synchronize cmake.
