### PR TITLE
fix tests without ROS PACKAGE_PATH

### DIFF
--- a/src/dynamic_graph/sot/dynamic_pinocchio/humanoid_robot.py
+++ b/src/dynamic_graph/sot/dynamic_pinocchio/humanoid_robot.py
@@ -200,7 +200,7 @@ class AbstractRobot(ABC):
             urdfFile = urdfPath
         if urdfDir is None:
             import os
-            urdfDir = os.environ["ROS_PACKAGE_PATH"].split(':')
+            urdfDir = os.environ.get("ROS_PACKAGE_PATH", "").split(':')
         if rootJointType is None:
             self.pinocchioModel = pinocchio.buildModelFromUrdf(urdfFile)
         else:


### PR DESCRIPTION
otherwise, when `$ROS_PACKAGE_PATH` is not defined:

```python
======================================================================
ERROR: test_build_robot_from_urdf (__main__.HumanoidRobotTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/src/sot-dynamic-pinocchio-3.6.3/tests/python/humanoid_robot.py", line 66, in test_build_robot_from_urdf
    Robot("test_build_robot_from_string", urdfFile=self.urdf_file_name)
  File "/src/sot-dynamic-pinocchio-3.6.3/tests/python/humanoid_robot.py", line 19, in __init__
    self.loadModelFromUrdf(urdfFile)
  File "/install/lib/python3/dist-packages/dynamic_graph/sot/dynamic_pinocchio/humanoid_robot.py", line 203, in loadModelFromUrdf
    urdfDir = os.environ["ROS_PACKAGE_PATH"].split(':')
  File "/usr/lib/python3.8/os.py", line 675, in __getitem__
    raise KeyError(key) from None
KeyError: 'ROS_PACKAGE_PATH'
```