### PR TITLE
fix submodule url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "cmake"]
 	path = cmake
-	url = git://github.com/jrl-umi3218/jrl-cmakemodules.git
+	url = https://github.com/jrl-umi3218/jrl-cmakemodules.git


### PR DESCRIPTION
ref. https://github.com/humanoid-path-planner/hpp-core/issues/256.

If someone prefer using another url scheme, git can globally be configured with eg.:
```
git config --global url."git@github.com:".insteadOf https://github.com/
```