### PR TITLE
Remove assert

### DIFF
--- a/src/dynamic_graph/sot/dynamic_pinocchio/humanoid_robot.py
+++ b/src/dynamic_graph/sot/dynamic_pinocchio/humanoid_robot.py
@@ -325,7 +325,6 @@ class AbstractRobot(ABC):
             + [0.0, 0.0, 0.0]  # Replace quaternion by RPY.
             + self.halfSitting[7:].tolist()
         )
-        assert self.halfSitting.shape[0] == self.dynamic.getDimension()
 
         # Set the device limits.
         def get(s):


### PR DESCRIPTION
  In some cases, the dimension of the robot in pinocchio is different from the
  dimension of the state vector. For example, for the Franka robot with a
  gripper, the gripper is the state vector since not controllable via ROS
  control.